### PR TITLE
fix: added iOS8 compatibility

### DIFF
--- a/JRNLocalNotificationCenter/JRNLocalNotificationCenter.m
+++ b/JRNLocalNotificationCenter/JRNLocalNotificationCenter.m
@@ -266,7 +266,13 @@ static JRNLocalNotificationCenter *defaultCenter;
         return nil;
     }
     
-    UIRemoteNotificationType notificationType = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+    NSUInteger notificationType;
+    if (!([[[UIDevice currentDevice] systemVersion] compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending)) {
+        notificationType = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];
+    }else{
+        notificationType = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+    }
+    
     if (self.checkRemoteNotificationAvailability && notificationType == UIRemoteNotificationTypeNone) {
         return nil;
     }


### PR DESCRIPTION
Hi!
On iOS8 [[UIApplication sharedApplication] enabledRemoteNotificationTypes] is deprecated. This fix check's verison of iOS, and uses adequate method.